### PR TITLE
Some (small) cosmetics 

### DIFF
--- a/esxidown.sh
+++ b/esxidown.sh
@@ -21,7 +21,7 @@ WAIT_TIME=10
 
 validate_shutdown()
 {
-    vim-cmd vmsvc/power.getstate $SRVID | grep -i "off\|Suspended" > /dev/null 2<&1
+    vim-cmd vmsvc/power.getstate $SRVID | grep -i "off" > /dev/null 2<&1
     STATUS=$?
 
     if [ $STATUS -ne 0 ]; then
@@ -53,7 +53,7 @@ for SRVID in $SERVERIDS
 do
     TRY=0
 
-    vim-cmd vmsvc/power.getstate $SRVID | grep -i "off" > /dev/null 2<&1
+    vim-cmd vmsvc/power.getstate $SRVID | grep -i "off\|Suspended" > /dev/null 2<&1
     STATUS=$?
 
     if [ $STATUS -ne 0 ]; then


### PR DESCRIPTION
Hi,

I found your script as I was searching for an easy way to power down my testing server in the evening. To fit my needs I changed some small things namely:
- set maintenance mode first
  just to prevent other machines from powering up, while I want to power down.
- reduced wait time and higher the times a shutdown is tried
  also the script would always wait a full minute even if a machine immediately powers down.
- changed query for vmid
  I have some annotations in my machines, with the old query he also wanted to power down my annotations
- ignore machines that are already in suspended mode
  do what it says.

I hope you find this helpful as well.
